### PR TITLE
Reselect the correct project on refresh

### DIFF
--- a/models.js
+++ b/models.js
@@ -31,6 +31,10 @@ Projects = Backbone.Collection.extend({
   initialize: function(models, options) {
     Backbone.Select.One.applyTo(this, models, options);
     this.user = options.user;
+
+    console.log("initializing listeners")
+    this.listenTo(this, "reset", this.reselect);
+    this.listenTo(this, "select:one", this.storeSelection);
   },
 
   parse: function(response) {


### PR DESCRIPTION
The event listeners were removed in a commit that was cleaning up the views correctly.  This looks like it was a mistake. 